### PR TITLE
fix(focus-manager): update focus manager tests to pass with the new TV layout in Zapp

### DIFF
--- a/applications/feature_app/config.cfg
+++ b/applications/feature_app/config.cfg
@@ -30,7 +30,7 @@ uiautomator2ServerInstallTimeout = 120000
 # ================ Samsung TV browser ================ #
 [general]
 platform = web
-app_version = 0.0.1
+app_version = 0.0.5
 app_id = 5a364b49e03b2f000d51a0de
 bundle_id = com.appfeatureapp
 building_blocks = applications/feature_app/tv/building_blocks/building_blocks.py

--- a/applications/feature_app/tv/tests/test_focus_manager.py
+++ b/applications/feature_app/tv/tests/test_focus_manager.py
@@ -24,7 +24,7 @@ class FocusManagerTests(BaseTest):
         PRINT('Step 1: Verify that application launched into home screen')
         self.building_blocks.screens['Home'].verify_in_screen()
 
-        accessibility_id = 'focusable-a8bd4db4-1880-44e3-84de-c4658cebb943-001-0'
+        accessibility_id = 'focusable-0657822b-4a2f-4524-81da-0f10db13a5e0-001-0'
         move_focus_and_verify(
             self.driver,
             2,
@@ -33,7 +33,7 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-3e76e082-27da-4aa0-be95-16acae85dea2-108785-9'
+        accessibility_id = 'focusable-6a4efb70-dd35-4d25-9e4f-016f9614d1c7-108785-9'
         move_focus_and_verify(
             self.driver,
             3,
@@ -43,7 +43,7 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-199d641b-bca8-49cc-bbe6-742fc29d5d17-7125723-0'
+        accessibility_id = 'focusable-9eda317d-20fc-4db9-9477-f5af17f95ad9-7125723-0'
         move_focus_and_verify(
             self.driver,
             4,
@@ -52,7 +52,7 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-3e76e082-27da-4aa0-be95-16acae85dea2-108785-9'
+        accessibility_id = 'focusable-6a4efb70-dd35-4d25-9e4f-016f9614d1c7-108785-9'
         move_focus_and_verify(
             self.driver,
             5,
@@ -71,45 +71,45 @@ class FocusManagerTests(BaseTest):
         self.building_blocks.screens['Horizontal List Screen'].navigate()
         self.driver.send_keys(RemoteControlKeys.DOWN, 2)
 
-        accessibility_id = 'focusable-91c0f4c7-a762-43c5-8984-847cc6bcbcbf-a3983053d1ebad89d3d442357a466789-0'
+        accessibility_id = 'focusable-9935e5f9-c0f7-48a7-8f22-2a13c28c4acf-a3983053d1ebad89d3d442357a466789-0'
         move_focus_and_verify(
             self.driver,
             3,
-            'verify if top most left item in top horizontal list component is focused when screen opens',
+            'verify if top most left item in top horizontal list component is focused when screen opens (vod_mp4_item_1)',
             None,
             accessibility_id
         )
 
-        accessibility_id = 'focusable-91c0f4c7-a762-43c5-8984-847cc6bcbcbf-a0276e224d8b7fd8d4250f182033ee8e-1'
+        accessibility_id = 'focusable-9935e5f9-c0f7-48a7-8f22-2a13c28c4acf-a0276e224d8b7fd8d4250f182033ee8e-1'
         move_focus_and_verify(
             self.driver,
             4,
-            'move focus manager to the second item in the first horizontal list component and verify that it is focused',
+            'move focus manager to the second item in the first horizontal list component and verify that it is focused (vod_mp4_item_2)',
             RemoteControlKeys.RIGHT,
             accessibility_id
         )
 
-        accessibility_id = 'focusable-f38054ea-2362-40af-9acc-e1801bc873bc-001-0'
+        accessibility_id = 'focusable-fdb69052-ec37-4a12-a030-ba810bfe6a4c-001-0'
         move_focus_and_verify(
             self.driver,
             5,
             'move focus manager to the second horizontal list on screen named "applicaster_cell_types" and verify if '
-            'most left item in the second horizontal list is focused',
+            'most left item in the second horizontal list is focused (video_feed)',
             RemoteControlKeys.DOWN,
             accessibility_id
         )
 
-        accessibility_id = 'focusable-f38054ea-2362-40af-9acc-e1801bc873bc-002-1'
+        accessibility_id = 'focusable-fdb69052-ec37-4a12-a030-ba810bfe6a4c-002-1'
         move_focus_and_verify(
             self.driver,
             6,
             'move focus manager to the second item in the second horizontal list on screen named "applicaster_cell_types"'
-            'verify if the second item in the second horizontal list in screen is focused',
+            'verify if the second item in the second horizontal list in screen is focused (current_program_feed)',
             RemoteControlKeys.RIGHT,
             accessibility_id
         )
 
-        accessibility_id = 'focusable-91c0f4c7-a762-43c5-8984-847cc6bcbcbf-a0276e224d8b7fd8d4250f182033ee8e-1'
+        accessibility_id = 'focusable-9935e5f9-c0f7-48a7-8f22-2a13c28c4acf-a0276e224d8b7fd8d4250f182033ee8e-1'
         move_focus_and_verify(
             self.driver,
             7,
@@ -129,7 +129,7 @@ class FocusManagerTests(BaseTest):
         self.building_blocks.screens['Hero Screen'].navigate()
         self.driver.send_keys(RemoteControlKeys.DOWN, 2)
 
-        accessibility_id = 'focusable-447f33ec-d1e2-4f75-a289-b256eb3d2a17-a3983053d1ebad89d3d442357a466789-0'
+        accessibility_id = 'focusable-bb5dd00a-cd10-483c-8c84-3976d95c97eb-a3983053d1ebad89d3d442357a466789-0'
         move_focus_and_verify(
             self.driver,
             3,
@@ -138,7 +138,7 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-447f33ec-d1e2-4f75-a289-b256eb3d2a17-108785-9'
+        accessibility_id = 'focusable-bb5dd00a-cd10-483c-8c84-3976d95c97eb-108785-9'
         move_focus_and_verify(
             self.driver,
             4,
@@ -147,7 +147,7 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-447f33ec-d1e2-4f75-a289-b256eb3d2a17-a3983053d1ebad89d3d442357a466789-0'
+        accessibility_id = 'focusable-bb5dd00a-cd10-483c-8c84-3976d95c97eb-a3983053d1ebad89d3d442357a466789-0'
         move_focus_and_verify(
             self.driver,
             5,
@@ -168,11 +168,11 @@ class FocusManagerTests(BaseTest):
         self.driver.send_keys(RemoteControlKeys.DOWN, 2)
 
         PRINT('Step 3: verify that the first item in the left menu is focused when screen picker screen opens and after 1 press down')
-        accessibility_id = 'focusable-ec93885e-da6b-4d17-8ab3-a5ee0bb769c3.ScreenSelector-32965-0'
+        accessibility_id = 'focusable-437d59bd-985a-4f74-8534-ac8d7981166d.ScreenSelector-58032-0'
         is_focused = self.driver.is_element_focused(accessibility_id)
         Logger.get_instance().log_assert(is_focused is True, '%s is not focused' % accessibility_id)
 
-        accessibility_id = 'focusable-a8bd4db4-1880-44e3-84de-c4658cebb943-001-0'
+        accessibility_id = 'focusable-0657822b-4a2f-4524-81da-0f10db13a5e0-001-0'
         move_focus_and_verify(
             self.driver,
             4,
@@ -182,17 +182,17 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-a8bd4db4-1880-44e3-84de-c4658cebb943-002-1'
+        accessibility_id = 'focusable-0657822b-4a2f-4524-81da-0f10db13a5e0-003-2'
         move_focus_and_verify(
             self.driver,
             5,
-            'move focus manager inside the screen picker grid component and verify that "current_program_feed" '
+            'move focus manager inside the screen picker grid component and verify that "channel_feed" '
             'becoming focused',
             RemoteControlKeys.DOWN,
             accessibility_id
         )
 
-        accessibility_id = 'focusable-ec93885e-da6b-4d17-8ab3-a5ee0bb769c3.ScreenSelector-32966-1'
+        accessibility_id = 'focusable-437d59bd-985a-4f74-8534-ac8d7981166d.ScreenSelector-58033-1'
         move_focus_and_verify(
             self.driver,
             6,
@@ -204,22 +204,22 @@ class FocusManagerTests(BaseTest):
     @pytest.mark.samsung_tv
     @pytest.mark.usefixtures('automation_driver')
     def test_move_focus_manager_in_top_menu_bar(self):
-        accessibility_id = 'focusable-91c0f4c7-a762-43c5-8984-847cc6bcbcbf-a3983053d1ebad89d3d442357a466789-0'
+        accessibility_id = 'focusable-9935e5f9-c0f7-48a7-8f22-2a13c28c4acf-a3983053d1ebad89d3d442357a466789-0'
         move_focus_and_verify(
             self.driver,
             1,
             'navigate from top menu bar to "Horizontal List Screen" and verify focus is on "vod_mp4_item_1" item '
-            'in "video_feed_xml_mp4_and_m3u8" Horizontal List component',
+            'in "vod_mp4_item_1" Horizontal List component',
             [RemoteControlKeys.UP, RemoteControlKeys.RIGHT, RemoteControlKeys.ENTER, RemoteControlKeys.DOWN],
             accessibility_id
         )
 
-        accessibility_id = 'focusable-447f33ec-d1e2-4f75-a289-b256eb3d2a17-a3983053d1ebad89d3d442357a466789-0'
+        accessibility_id = 'focusable-bb5dd00a-cd10-483c-8c84-3976d95c97eb-a3983053d1ebad89d3d442357a466789-0'
         move_focus_and_verify(
             self.driver,
             2,
             'navigate from top menu bar to "Hero Screen" and verify focus is on "vod_mp4_item_1" item '
-            'in "video_feed_xml_mp4_and_m3u8" Hero component',
+            'in "vod_mp4_item_1" Hero component',
             [RemoteControlKeys.UP, RemoteControlKeys.RIGHT, RemoteControlKeys.ENTER, RemoteControlKeys.DOWN],
             accessibility_id
         )


### PR DESCRIPTION
This PR updates the focus manger tests for Samsung Tv Web tests to pass against the new layout in Zapp named TV.