### PR TITLE
feat(IMA): cover IMA mobile plugin with tests

### DIFF
--- a/applications/feature_app/mobile/building_blocks/building_blocks.py
+++ b/applications/feature_app/mobile/building_blocks/building_blocks.py
@@ -8,6 +8,8 @@ from src.data_providers.rivers_data_provider import RiversDataProvider
 from applications.feature_app.feature_app_player import FeatureAppPlayer
 from src.utils.print import PRINT
 
+from applications.feature_app.mobile.building_blocks.demo_pre_hook import DemoPreHook
+
 """
 Global Defines
 """
@@ -45,5 +47,6 @@ class BuildingBlocks(BuildingBlocksInterface):
         # Setup internal screens
         self.screens['search_screen'] = SearchScreen(self.test)
         self.screens['player_screen'] = FeatureAppPlayer(self.test)
+        self.screens['demo_pre_hook'] = DemoPreHook(self.test)
         self.screens['ListScreen'].set_screen_loading_timeout(5)
         self.screens['GridScreen'].set_screen_loading_timeout(5)

--- a/applications/feature_app/mobile/building_blocks/demo_pre_hook.py
+++ b/applications/feature_app/mobile/building_blocks/demo_pre_hook.py
@@ -1,0 +1,46 @@
+
+
+from src.generic_building_blocks.mobile.screens.mobile_screen import MobileScreen
+from src.utils.logger import Logger
+from src.utils.print import PRINT
+from src.global_defines import ScreenType
+from src.generic_building_blocks.generic_screen import FAILED_TO_VERIFY_SCREEN
+
+"""
+Class Defines
+"""
+SUCCESS_BUTTON_TITLE = 'Success'
+ERROR_BUTTON_TITLE = 'Error'
+CANCEL_BUTTON_TITLE = 'Cancel'
+
+
+class DemoPreHook(MobileScreen):
+    """
+    Public Implementation
+    """
+    def enter_with_success(self):
+        self.__press_element_by_title__(SUCCESS_BUTTON_TITLE)
+
+    def enter_with_error(self):
+        self.__press_element_by_title__(ERROR_BUTTON_TITLE)
+
+    def cancel_enter(self):
+        self.__press_element_by_title__(CANCEL_BUTTON_TITLE)
+
+    def get_screen_id(self):
+        return 'Quick Brick Hooks test'
+
+    def get_screen_type(self):
+        return ScreenType.STANDALONE_SCREEN
+
+    """
+    Private Implementation
+    """
+    def __press_element_by_title__(self, title):
+        element = self.test.driver.find_element_by_text(title, retries=3)
+        Logger.get_instance().log_assert(element, 'Element with title %s not found on the demo pre hook screen' % title)
+        PRINT('     Test will press on "%s" button in the demo pre hook screen' % title)
+        element.click()
+
+    def __init__(self, test):
+        MobileScreen.__init__(self, test)

--- a/applications/feature_app/mobile/tests/test_google_ima.py
+++ b/applications/feature_app/mobile/tests/test_google_ima.py
@@ -9,7 +9,6 @@ from src.utils.logger import Logger
 
 class GoogleInteractiveMediaAdsTests(BaseTest):
     @pytest.mark.usefixtures('automation_driver')
-    @pytest.mark.ima
     def test_verify_playing_vast_ads_from_json_feed(self):
         grid_screen = self.building_blocks.screens['GridScreen']
         pre_hook = self.building_blocks.screens['demo_pre_hook']

--- a/applications/feature_app/mobile/tests/test_google_ima.py
+++ b/applications/feature_app/mobile/tests/test_google_ima.py
@@ -7,9 +7,35 @@ from src.global_defines import PlatformType
 from src.utils.logger import Logger
 
 
+"""
+Global Defines
+"""
+VMAP_PRE_ROLL_URL = 'https://pubads.g.doubleclick.net/gampad/ads?slotname=/124319096/external/ad_rule_samples&sz=' \
+                    '640x480&ciu_szs=300x250&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&url=&unvie' \
+                    'wed_position_start=1&output=xml_vast3&impl=s&env=vp&gdfp_req=1&ad_rule=0&vad_type=linear&vpo' \
+                    's=preroll&pod=1&ppos=1&lip=true&min_ad_duration=0&max_ad_duration=30000&vrid=6256&video_doc_' \
+                    'id=short_onecue&cmsid=496&kfa=0&tfcd=0'
+
+VMAP_MID_ROLL_URL = 'https://pubads.g.doubleclick.net/gampad/ads?slotname=/124319096/external/ad_rule_samples&sz=' \
+                    '640x480&ciu_szs=300x250&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&url=&unvie' \
+                    'wed_position_start=1&output=xml_vast3&impl=s&env=vp&gdfp_req=1&ad_rule=0&cue=15000&vad_type=' \
+                    'linear&vpos=midroll&pod=2&mridx=1&rmridx=1&ppos=1&lip=true&min_ad_duration=0&max_ad_duration' \
+                    '=30000&vrid=6256&video_doc_id=short_onecue&cmsid=496&kfa=0&tfcd=0'
+
+VMAP_POST_ROLL_URL = 'https://pubads.g.doubleclick.net/gampad/ads?slotname=/124319096/external/ad_rule_samples&sz' \
+                     '=640x480&ciu_szs=300x250&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&url=&unv' \
+                     'iewed_position_start=1&output=xml_vast3&impl=s&env=vp&gdfp_req=1&ad_rule=0&vad_type=linear&' \
+                     'vpos=postroll&pod=3&ppos=1&lip=true&min_ad_duration=0&max_ad_duration=30000&vrid=6256&video' \
+                     '_doc_id=short_onecue&cmsid=496&kfa=0&tfcd=0'
+
+VMAP_VOD_ITEM_NAME = 'vod_with_play_next' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id2'
+VAST_VOD_ITEM_NAME = 'm3u8_vod' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id1'
+VMAP_ADV_URL = 'https://assets-secure.applicaster.com/qa/zapp_qa/automation/advertising/pre_mid_post_roll_vmap.xml'
+
+
 class GoogleInteractiveMediaAdsTests(BaseTest):
     @pytest.mark.usefixtures('automation_driver')
-    def test_verify_playing_vast_ads_from_json_feed(self):
+    def test_verify_playing_vast_adv_from_json_feed(self):
         grid_screen = self.building_blocks.screens['GridScreen']
         pre_hook = self.building_blocks.screens['demo_pre_hook']
         platform_type = Configuration.get_instance().platform_type()
@@ -17,9 +43,8 @@ class GoogleInteractiveMediaAdsTests(BaseTest):
         PRINT('Step 1: Navigate to "GridScreen" screen')
         grid_screen.navigate()
 
-        item_name = 'm3u8_vod' if platform_type == PlatformType.ANDROID else 'Id1'
-        PRINT('Step 2: Press on item "%s" element on screen' % item_name)
-        element = self.driver.find_element_by_text(item_name)
+        PRINT('Step 2: Press on item "%s" element on screen' % VAST_VOD_ITEM_NAME)
+        element = self.driver.find_element_by_text(VAST_VOD_ITEM_NAME)
         element.click()
 
         PRINT('Step 3: Pass the presented pre hook screen with success, in order to watch the video')
@@ -37,7 +62,47 @@ class GoogleInteractiveMediaAdsTests(BaseTest):
 
         PRINT('Step 5: Verify that the pre-roll completes playing and that the video starts instead')
         timeout = 15
-        PRINT('     Step 5.1: Wait %s seconds until the pre-roll will complete' % timeout)
+        PRINT('     Step 5.1: Wait %s seconds until the pre-roll will complete playing the adv' % timeout)
         self.driver.wait(15)
-        PRINT('     Step 5.2: Verify that the expected video is playing the streaming correctly')
+        element = self.driver.find_element_by_text(pre_roll_unit_id)
+        Logger.get_instance().log_assert(element is None, 'pre-roll dismissed from screen successfully')
+        PRINT('     Step 5.2: Pre-roll dismissed from screen successfully')
+        PRINT('     Step 5.3: Verify that the expected video is playing the streaming correctly')
         self.building_blocks.screens['player_screen'].verify_stream_is_playing()
+
+    def wait_until_adv_is_gone(self, unit_id, timeout=20):
+        for i in range(timeout):
+            element = self.driver.find_element_by_text(unit_id)
+            if element is None:
+                return True
+            self.driver.wait(1)
+        return False
+
+    def verify_adv(self, step, section, display_timeout, dismiss_timeout, expected_unit_id):
+        step = str(step)
+        PRINT('Step %s: Verify playing of VMAP %s with id %s' % (step, section, expected_unit_id))
+        element = self.driver.find_element_by_text(VMAP_ADV_URL, display_timeout)
+        Logger.get_instance().log_assert(element, 'Test failed displaying VMAP %s with id %s' % (section, expected_unit_id))
+        PRINT('     Step %s.2: Wait for the %s to complete' % (step, section))
+        is_gone = self.wait_until_adv_is_gone(VMAP_ADV_URL, dismiss_timeout)
+        Logger.get_instance().log_assert(is_gone, '%s did not dismiss after %s' % (section, dismiss_timeout))
+        PRINT('     Step %s.3: %s adv displayed and dismissed successfully' % (step, section))
+
+    @pytest.mark.usefixtures('automation_driver')
+    def test_verify_playing_vmap_adv_from_ui_builder_fallback(self):
+        grid_screen = self.building_blocks.screens['GridScreen']
+        pre_hook = self.building_blocks.screens['demo_pre_hook']
+
+        PRINT('Step 1: Navigate to "GridScreen" screen')
+        grid_screen.navigate()
+
+        PRINT('Step 2: Press on item "%s" element on screen' % VMAP_VOD_ITEM_NAME)
+        element = self.driver.find_element_by_text(VMAP_VOD_ITEM_NAME)
+        element.click()
+        PRINT('     Step 2.1: Wait for pre hook and dismiss it')
+        self.driver.wait(2)
+        pre_hook.enter_with_success()
+
+        self.verify_adv(3, 'pre-roll', 20, 15, VMAP_PRE_ROLL_URL)
+        self.verify_adv(4, 'mid-roll', 30, 15, VMAP_MID_ROLL_URL)
+        self.verify_adv(5, 'post-roll', 30, 15, VMAP_POST_ROLL_URL)

--- a/applications/feature_app/mobile/tests/test_google_ima.py
+++ b/applications/feature_app/mobile/tests/test_google_ima.py
@@ -38,7 +38,6 @@ class GoogleInteractiveMediaAdsTests(BaseTest):
     def test_verify_playing_vast_adv_from_json_feed(self):
         grid_screen = self.building_blocks.screens['GridScreen']
         pre_hook = self.building_blocks.screens['demo_pre_hook']
-        platform_type = Configuration.get_instance().platform_type()
 
         PRINT('Step 1: Navigate to "GridScreen" screen')
         grid_screen.navigate()

--- a/applications/feature_app/mobile/tests/test_google_ima.py
+++ b/applications/feature_app/mobile/tests/test_google_ima.py
@@ -1,0 +1,44 @@
+
+import pytest
+
+from src.automation_manager.automation_manager import automation_driver
+from src.base_test import BaseTest, PRINT, Configuration
+from src.global_defines import PlatformType
+from src.utils.logger import Logger
+
+
+class GoogleInteractiveMediaAdsTests(BaseTest):
+    @pytest.mark.usefixtures('automation_driver')
+    @pytest.mark.ima
+    def test_verify_playing_vast_ads_from_json_feed(self):
+        grid_screen = self.building_blocks.screens['GridScreen']
+        pre_hook = self.building_blocks.screens['demo_pre_hook']
+        platform_type = Configuration.get_instance().platform_type()
+
+        PRINT('Step 1: Navigate to "GridScreen" screen')
+        grid_screen.navigate()
+
+        item_name = 'm3u8_vod' if platform_type == PlatformType.ANDROID else 'Id1'
+        PRINT('Step 2: Press on item "%s" element on screen' % item_name)
+        element = self.driver.find_element_by_text(item_name)
+        element.click()
+
+        PRINT('Step 3: Pass the presented pre hook screen with success, in order to watch the video')
+        PRINT('     Step 3.1: Verify that the demo pre hook screen is presented')
+        pre_hook.verify_in_screen(retries=3)
+        PRINT('     Step 3.2: Dismiss the pre hook screen with success')
+        pre_hook.enter_with_success()
+
+        PRINT('Step 4: Verify that a VAST pre-roll adv is presented before the video start playing')
+        pre_roll_unit_id = \
+            'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dredirectlinear&correlator='
+        element = self.driver.find_element_by_text(pre_roll_unit_id, 20)
+        Logger.get_instance().log_assert(element, 'Test failed displaying video pre roll adv with id: "%s"' % pre_roll_unit_id)
+        PRINT('Test verified successfully pre-roll video adv with id "%s"' % pre_roll_unit_id)
+
+        PRINT('Step 5: Verify that the pre-roll completes playing and that the video starts instead')
+        timeout = 15
+        PRINT('     Step 5.1: Wait %s seconds until the pre-roll will complete' % timeout)
+        self.driver.wait(15)
+        PRINT('     Step 5.2: Verify that the expected video is playing the streaming correctly')
+        self.building_blocks.screens['player_screen'].verify_stream_is_playing()

--- a/applications/feature_app/mobile/tests/test_launch_to_home.py
+++ b/applications/feature_app/mobile/tests/test_launch_to_home.py
@@ -7,7 +7,7 @@ from src.base_test import BaseTest
 
 
 @pytest.mark.qb_android_mobile
-# @pytest.mark.qb_ios_mobile
+@pytest.mark.qb_ios_mobile
 @pytest.mark.usefixtures('automation_driver')
 class LaunchToHomeTest(BaseTest):
     def test_launch_to_home(self):

--- a/applications/feature_app/mobile/tests/test_launch_to_home.py
+++ b/applications/feature_app/mobile/tests/test_launch_to_home.py
@@ -7,7 +7,7 @@ from src.base_test import BaseTest
 
 
 @pytest.mark.qb_android_mobile
-@pytest.mark.qb_ios_mobile
+# @pytest.mark.qb_ios_mobile
 @pytest.mark.usefixtures('automation_driver')
 class LaunchToHomeTest(BaseTest):
     def test_launch_to_home(self):

--- a/applications/feature_app/mobile/tests/test_launch_to_home.py
+++ b/applications/feature_app/mobile/tests/test_launch_to_home.py
@@ -7,7 +7,6 @@ from src.base_test import BaseTest
 
 
 @pytest.mark.qb_android_mobile
-@pytest.mark.qb_ios_mobile
 @pytest.mark.usefixtures('automation_driver')
 class LaunchToHomeTest(BaseTest):
     def test_launch_to_home(self):

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -16,6 +16,7 @@ class PlayerTest(BaseTest):
 
     def find_play_and_verify(self, screen_name, vod_name):
         screen = self.building_blocks.screens[screen_name]
+        pre_hook = self.building_blocks.screens['demo_pre_hook']
 
         PRINT('Step 1: Navigate to "%s" screen' % screen_name)
         screen.navigate()
@@ -25,16 +26,19 @@ class PlayerTest(BaseTest):
         element = screen.search_for_item_by_text(vod_name)
         PRINT('     Step 2.2: Tap on "%s" vod item in order to start playing it' % vod_name)
         element.click()
+        if Configuration.get_instance().platform_type() == PlatformType.IOS:
+            PRINT('     Step 2.3: Dismiss the pre hook screen with Success')
+            pre_hook.enter_with_success()
 
-        PRINT('     Step 2.3: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
+        PRINT('     Step 2.4: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
         self.driver.wait(START_PLAYING_VOD_TIMEOUT)
-        PRINT('     Step 2.4: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
+        PRINT('     Step 2.5: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
 
         PRINT('Step 3.0: Verify that the streaming is playing')
         self.building_blocks.screens['player_screen'].verify_stream_is_playing()
         PRINT('     Step 3.1: Streaming is playing correctly')
 
-    # @pytest.mark.qb_ios_mobile_nightly
+    @pytest.mark.qb_ios_mobile
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_json_feed_vod_streaming_in_list_component(self):

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -27,7 +27,10 @@ class PlayerTest(BaseTest):
         PRINT('     Step 2.2: Tap on "%s" vod item in order to start playing it' % vod_name)
         element.click()
         if Configuration.get_instance().platform_type() == PlatformType.IOS:
-            PRINT('     Step 2.3: Dismiss the pre hook screen with success')
+            PRINT('     Step 2.3: Pass the presented pre hook screen with success, in order to watch the video')
+            PRINT('     Step 2.4: Verify that the demo pre hook screen is presented')
+            pre_hook.verify_in_screen(retries=3)
+            PRINT('     Step 2.5: Dismiss the pre hook screen with success')
             pre_hook.enter_with_success()
 
         PRINT('     Step 2.3: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -4,7 +4,6 @@ import pytest
 from src.automation_manager.automation_manager import automation_driver
 from src.base_test import BaseTest, PRINT, Configuration
 from src.global_defines import PlatformType
-from src.utils.logger import Logger
 
 """
 Global Defines
@@ -17,7 +16,6 @@ class PlayerTest(BaseTest):
 
     def find_play_and_verify(self, screen_name, vod_name):
         screen = self.building_blocks.screens[screen_name]
-        pre_hook = self.building_blocks.screens['demo_pre_hook']
 
         PRINT('Step 1: Navigate to "%s" screen' % screen_name)
         screen.navigate()
@@ -27,26 +25,20 @@ class PlayerTest(BaseTest):
         element = screen.search_for_item_by_text(vod_name)
         PRINT('     Step 2.2: Tap on "%s" vod item in order to start playing it' % vod_name)
         element.click()
-        if Configuration.get_instance().platform_type() == PlatformType.IOS:
-            PRINT('     Step 2.3: Dismiss the pre hook screen with Success')
-            Logger.get_instance().take_screenshot('before_pre_hook_dismissal')
-            pre_hook.enter_with_success()
-        Logger.get_instance().take_screenshot('after_pre_hook_dismissal')
-        self.driver.wait(3)
-        Logger.get_instance().take_screenshot('after_3_seconds_in_buffering')
-        PRINT('     Step 2.4: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
+
+        PRINT('     Step 2.3: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
         self.driver.wait(START_PLAYING_VOD_TIMEOUT)
-        PRINT('     Step 2.5: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
+        PRINT('     Step 2.4: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
 
         PRINT('Step 3.0: Verify that the streaming is playing')
         self.building_blocks.screens['player_screen'].verify_stream_is_playing()
         PRINT('     Step 3.1: Streaming is playing correctly')
 
-    @pytest.mark.qb_ios_mobile
+    # @pytest.mark.qb_ios_mobile_nightly
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_json_feed_vod_streaming_in_list_component(self):
-        item_name = 'm3u8_vod' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id4'
+        item_name = 'm3u8_vod' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id1'
         self.find_play_and_verify(SCREEN_NAME, item_name)
 
     @pytest.mark.usefixtures('automation_driver')

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -16,6 +16,7 @@ class PlayerTest(BaseTest):
 
     def find_play_and_verify(self, screen_name, vod_name):
         screen = self.building_blocks.screens[screen_name]
+        pre_hook = self.building_blocks.screens['demo_pre_hook']
 
         PRINT('Step 1: Navigate to "%s" screen' % screen_name)
         screen.navigate()
@@ -25,6 +26,9 @@ class PlayerTest(BaseTest):
         element = screen.search_for_item_by_text(vod_name)
         PRINT('     Step 2.2: Tap on "%s" vod item in order to start playing it' % vod_name)
         element.click()
+        if Configuration.get_instance().platform_type() == PlatformType.IOS:
+            PRINT('     Step 2.3: Dismiss the pre hook screen with success')
+            pre_hook.enter_with_success()
 
         PRINT('     Step 2.3: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
         self.driver.wait(START_PLAYING_VOD_TIMEOUT)
@@ -34,7 +38,7 @@ class PlayerTest(BaseTest):
         self.building_blocks.screens['player_screen'].verify_stream_is_playing()
         PRINT('     Step 3.1: Streaming is playing correctly')
 
-    # @pytest.mark.qb_ios_mobile_nightly
+    @pytest.mark.qb_ios_mobile
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_json_feed_vod_streaming_in_list_component(self):

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -4,6 +4,7 @@ import pytest
 from src.automation_manager.automation_manager import automation_driver
 from src.base_test import BaseTest, PRINT, Configuration
 from src.global_defines import PlatformType
+from src.utils.logger import Logger
 
 """
 Global Defines
@@ -28,8 +29,11 @@ class PlayerTest(BaseTest):
         element.click()
         if Configuration.get_instance().platform_type() == PlatformType.IOS:
             PRINT('     Step 2.3: Dismiss the pre hook screen with Success')
+            Logger.get_instance().take_screenshot('before_pre_hook_dismissal')
             pre_hook.enter_with_success()
-
+        Logger.get_instance().take_screenshot('after_pre_hook_dismissal')
+        self.driver.wait(3)
+        Logger.get_instance().take_screenshot('after_3_seconds_in_buffering')
         PRINT('     Step 2.4: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
         self.driver.wait(START_PLAYING_VOD_TIMEOUT)
         PRINT('     Step 2.5: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
@@ -42,7 +46,7 @@ class PlayerTest(BaseTest):
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_json_feed_vod_streaming_in_list_component(self):
-        item_name = 'm3u8_vod' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id1'
+        item_name = 'm3u8_vod' if Configuration.get_instance().platform_type() == PlatformType.ANDROID else 'Id4'
         self.find_play_and_verify(SCREEN_NAME, item_name)
 
     @pytest.mark.usefixtures('automation_driver')


### PR DESCRIPTION
This PR adding a UI Tests that cover great percentage of the IMA plugin.

Test cases:

- Verify playing a **pre-roll** of **VAST** adv id from a json feed DS.

- Verify playing a **pre-roll** of **VMAP** adv id from UIBuilder fallback when no adv found in the json DSP.
- Verify playing a **mid-roll** of **VMAP** adv id from UIBuilder fallback when no adv found in the json DSP.
- Verify playing a **post-roll** of **VMAP** adv id from UIBuilder fallback when no adv found in the json DSP.
- Verify a pre-hook screen plugin


The tests performed on QB iOS Mobile app, we are waiting for the addition of accessibility ids for IMA android plugin. 

**The tests exposed an app crash when player was trying to play a VMAP post roll, Jira ticket: https://applicaster.atlassian.net/browse/ZPP-2589**

**Both tests will be added to the nightly run**