### PR TITLE
feat(nightly-run): enable tvOS and iOS tests into the nightly run

### DIFF
--- a/applications/feature_app/config.cfg
+++ b/applications/feature_app/config.cfg
@@ -1,6 +1,6 @@
 # ============================== iOS Simulator ============================== #
 [general]
-app_version = 0.1.0.0
+app_version = 0.1.0.1
 app_id = 5a364b49e03b2f000d51a0de
 building_blocks = applications/feature_app/mobile/building_blocks/building_blocks.py
 
@@ -59,7 +59,7 @@ uiautomator2ServerInstallTimeout = 120000
 # =============== tvOS Simulator =============== #
 [general]
 platform = tv_os
-app_version = 1.0.0.1
+app_version = 1.0.0.2
 app_id = 5a364b49e03b2f000d51a0de
 building_blocks = applications/feature_app/tv/building_blocks/building_blocks.py
 
@@ -68,5 +68,4 @@ bundleId = com.appfeatureapp
 platformVersion = 13.3
 deviceName = Apple TV
 automationName = XCUITest
-autoLaunch = true
 # =============================================== #

--- a/applications/feature_app/config.cfg
+++ b/applications/feature_app/config.cfg
@@ -8,6 +8,7 @@ building_blocks = applications/feature_app/mobile/building_blocks/building_block
 bundleId = com.featureappqbmobile
 platformVersion = 13.3
 deviceName = iPhone 11
+automationName = XCUITest
 # =========================================================================== #
 
 
@@ -55,6 +56,7 @@ deviceName = emulator-5554
 automationName = UiAutomator2
 uiautomator2ServerInstallTimeout = 120000
 # =============================================== #
+
 
 # =============== tvOS Simulator =============== #
 [general]

--- a/applications/feature_app/mobile/tests/test_grid_component.py
+++ b/applications/feature_app/mobile/tests/test_grid_component.py
@@ -5,6 +5,11 @@ from src.automation_manager.automation_manager import automation_driver
 from src.base_test import BaseTest, PRINT, Configuration
 from src.global_defines import PlatformType
 
+"""
+Global Defines
+"""
+PLATFORM = Configuration.get_instance().platform_type()
+
 
 class GridComponentTests(BaseTest):
 
@@ -16,15 +21,17 @@ class GridComponentTests(BaseTest):
         PRINT('     Step %s.2: Click on "%s" item' % (step_index, item_name))
         element.click()
 
-        PRINT('     Step %s.3: Wait %s seconds until that the screen will load' % (step_index, load_timeout))
-        self.driver.wait(load_timeout)
-        PRINT('     Step %s.4: Finished waiting for the screen to load' % step_index)
+        if load_timeout > 0:
+            PRINT('     Step %s.3: Wait %s seconds until that the screen will load' % (step_index, load_timeout))
+            self.driver.wait(load_timeout)
+            PRINT('     Step %s.4: Finished waiting for the screen to load' % step_index)
 
-    # @pytest.mark.qb_ios_mobile_nightly
+    @pytest.mark.qb_ios_mobile_nightly
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_play_vod_item_in_feed_of_feeds_connected_screen(self):
         grid_screen = self.building_blocks.screens['GridScreen']
+        pre_hook = self.building_blocks.screens['demo_pre_hook']
         platform_type = Configuration.get_instance().platform_type()
 
         PRINT('Step 1: Navigate to "GridScreen" screen')
@@ -46,12 +53,23 @@ class GridComponentTests(BaseTest):
             grid_screen,
             3,
             'Press on a VOD item with id  "%s"' % item_name,
-            10
+            1
         )
 
-        PRINT('Step 4.0: Verify that the streaming is playing')
+        if Configuration.get_instance().platform_type() == PlatformType.IOS:
+            PRINT('Step 4: Verify that the pre hook screen is presented and dismiss it')
+            pre_hook.verify_in_screen(retries=3)
+            PRINT('     Step 4.1: Pre hook screen is presented correctly')
+            pre_hook.enter_with_success()
+            PRINT('     Step 4.2: Pre hook screen dismissed')
+            PRINT('     Step 4.3: Wait 10 seconds until the streaming will start')
+
+        PRINT('Wait 10 seconds until that the streaming will start')
+        self.driver.wait(10)
+
+        PRINT('Step 5: Verify that the streaming is playing correctly')
         self.building_blocks.screens['player_screen'].verify_stream_is_playing()
-        PRINT('     Step 4.1: Streaming is playing correctly')
+        PRINT('     Step 5.1: Streaming is playing correctly')
 
     def shortDescription(self, test_name) -> str:
         return 'test_play_vod_item_in_feed_of_feeds_connected_screen:\n' \

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -8,7 +8,7 @@ from src.global_defines import PlatformType
 """
 Global Defines
 """
-START_PLAYING_VOD_TIMEOUT = 10
+START_PLAYING_VOD_TIMEOUT = 15
 SCREEN_NAME = 'ListScreen'
 
 

--- a/applications/feature_app/mobile/tests/test_screen_pre_hook.py
+++ b/applications/feature_app/mobile/tests/test_screen_pre_hook.py
@@ -37,7 +37,7 @@ class ScreenPreHookTests(BaseTest):
         PRINT('     Step 3.1: Verify we fell back to "ListScreen" screen successfully')
         list_screen.verify_in_screen(retries=5)
 
-    # @pytest.mark.qb_ios_mobile_nightly
+    @pytest.mark.qb_ios_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_pre_hook_handle_error(self):
         screen_with_pre_hook = self.building_blocks.screens[SCREEN_NAME]

--- a/applications/feature_app/mobile/tests/test_url_schemes.py
+++ b/applications/feature_app/mobile/tests/test_url_schemes.py
@@ -14,6 +14,7 @@ SCREEN_NAME = 'UrlSchemes'
 
 
 class UrlSchemesTests(BaseTest):
+    @pytest.mark.qb_ios_mobile_nightly
     @pytest.mark.qb_android_mobile_nightly
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_url_scheme_to_screen_by_id(self):
@@ -26,6 +27,7 @@ class UrlSchemesTests(BaseTest):
 
         if Configuration.get_instance().platform_type() == PlatformType.IOS:
             PRINT('     Step 2.1: Wait for pop up alert message and accept it')
+            self.driver.accept_alert_message()
             self.driver.accept_alert_message()
 
         PRINT('Step 3: Verify we navigated successfully to "HorizontalList" screen')

--- a/applications/feature_app/tv/tests/test_back_navigation.py
+++ b/applications/feature_app/tv/tests/test_back_navigation.py
@@ -8,7 +8,7 @@ from src.utils.print import PRINT
 from src.base_test import BaseTest
 
 
-# @pytest.mark.tv_os
+@pytest.mark.tv_os_nightly
 @pytest.mark.samsung_tv
 @pytest.mark.usefixtures('automation_driver')
 class BackNavigationsBetweenScreenTest(BaseTest):
@@ -32,7 +32,7 @@ class BackNavigationsBetweenScreenTest(BaseTest):
         return 'TestRail C17449 - Verify navigating between 3 screen'
 
 
-# @pytest.mark.tv_os_nighly
+@pytest.mark.tv_os_nightly
 @pytest.mark.samsung_tv
 @pytest.mark.usefixtures('automation_driver')
 class BackNavigationFromScreenPickerTest(BaseTest):
@@ -56,7 +56,7 @@ class BackNavigationFromScreenPickerTest(BaseTest):
         return 'C17451 - Verify navigating inside Screen Picker tabs'
 
 
-#@pytest.mark.tv_os
+@pytest.mark.tv_os_nightly
 @pytest.mark.android_tv
 @pytest.mark.samsung_tv
 @pytest.mark.usefixtures('automation_driver')
@@ -79,7 +79,7 @@ class BackNavigationFromPlayerTest(BaseTest):
         return 'C17452 - Verify navigating back from player screen'
 
 
-# @pytest.mark.tv_os_nightly
+@pytest.mark.tv_os_nightly
 @pytest.mark.samsung_tv
 @pytest.mark.android_tv
 @pytest.mark.usefixtures('automation_driver')

--- a/applications/feature_app/tv/tests/test_player.py
+++ b/applications/feature_app/tv/tests/test_player.py
@@ -7,7 +7,7 @@ from src.global_defines import RemoteControlKeys
 
 
 class PlayerTest(BaseTest):
-    # @pytest.mark.tv_os
+    @pytest.mark.tv_os_nightly
     @pytest.mark.android_tv
     @pytest.mark.usefixtures('automation_driver')
     def test_verify_vod_streaming(self):

--- a/applications/feature_app/tv/tests/test_player.py
+++ b/applications/feature_app/tv/tests/test_player.py
@@ -13,7 +13,7 @@ class PlayerTest(BaseTest):
     def test_verify_vod_streaming(self):
         PRINT('Step 1: Start playing "video_feed" vod item from the first component')
         self.driver.send_keys(RemoteControlKeys.ENTER)
-        timeout = 10
+        timeout = 15
         PRINT('     Step 1.1: Wait %s seconds until the streaming will start' % timeout)
         self.driver.wait(timeout)
 

--- a/base_config.cfg
+++ b/base_config.cfg
@@ -6,5 +6,5 @@ platform = iOS
 host = http://127.0.0.1:4723/wd/hub
 noReset = true
 fullReset = false
-autoLaunch = false
+autoLaunch = true
 # =============================================== #


### PR DESCRIPTION
Added tests:

iOS:
- test_play_vod_item_in_feed_of_feeds_connected_screen
- test_pre_hook_handle_error
- test_verify_url_scheme_to_screen_by_id


tvOS:
- BackNavigationsBetweenScreenTest
- BackNavigationFromScreenPickerTest
- test_verify_vod_streaming
- 
