### PR TITLE
feat(analytics-manager): add analytics manager that reads reported analytics events from any log file

### DIFF
--- a/src/analytics/analytics_manager.py
+++ b/src/analytics/analytics_manager.py
@@ -1,0 +1,58 @@
+
+from src.utils.logger import Logger
+from src.utils.print import PRINT
+from src.configuration.configuration import Configuration
+
+from json import loads
+
+'''
+Global Defines
+'''
+EVENT_PREFIX = 'AutomationAnalyticsEvent'
+
+
+class AnalyticsManager(object):
+    """
+    Public Implementation
+    """
+    def verify_events(self, events):
+        if isinstance(events, dict):
+            events = [events]
+
+        log = self.__get_log__()
+        for test_event in events:
+            event_found = False
+            for line in log:
+                if self.event_prefix_ in line:
+                    log_event = loads(line.split(self.event_prefix_)[1])
+                    if test_event.items() == log_event.items():
+                        event_found = True
+                        break
+            Logger.get_instance().log_assert(
+                event_found,
+                'Analytic event "%s" was not reported during the test run,\nDifference found in: %s'
+                % (test_event, test_event.items() - log_event.items())
+            )
+            PRINT('Analytics following analytic event reported correctly:')
+            PRINT(test_event, text_color='white')
+
+        return True
+
+    def print_events(self):
+        log = self.__get_log__()
+        for line in log:
+            if self.event_prefix_ in line:
+                print(line)
+
+    """
+    Private Implementation
+    """
+    def __init__(self,
+                 log_file_path=Configuration.get_instance().get('general', 'yarn_server_log'),
+                 event_prefix=EVENT_PREFIX):
+        self.log_file_path_ = log_file_path
+        self.event_prefix_ = event_prefix
+
+    def __get_log__(self):
+        return open(self.log_file_path_, 'r')
+

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -9,7 +9,6 @@ from src.configuration.configuration import Configuration
 
 from src.analytics.analytics_manager import AnalyticsManager
 
-
 '''
 Global Defines
 '''

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -7,6 +7,8 @@ from src.utils.print import PRINT
 from src.utils.logger import Logger
 from src.configuration.configuration import Configuration
 
+from src.analytics.analytics_manager import AnalyticsManager
+
 
 '''
 Global Defines
@@ -38,7 +40,10 @@ class BaseTest(unittest.TestCase):
         # Boot step 2: Init the needed building blocks for test
         self.__setup_building_blocks__()
 
-        # Boot step 3: Run ui boot steps
+        # Boot step 3: Init analytics manager
+        self.__setup_analytics_manager__()
+
+        # Boot step 4: Run ui boot steps
         self.__ui_boot_step__()
 
     def tearDown(self):
@@ -82,3 +87,7 @@ class BaseTest(unittest.TestCase):
         Logger.get_instance().take_screenshot('tear_down')
         Logger.get_instance().close_logs()
         self.driver.terminate_app()
+
+    def __setup_analytics_manager__(self):
+        if Configuration.get_instance().get('general', 'yarn_server_log'):
+            self.analytics_manager = AnalyticsManager()

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -65,6 +65,14 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(0, 1, exp)
 
     def __ui_boot_step__(self):
+        """
+        # When pytest start running at test its performing a few boot steps that found in BaseTestboot sequence,
+        # some of them are a UI actions and some are just initialising the test it self.
+        # In one of the steps its doing a call to boot_step() method that is must be override as part of the
+        # building_blocks.py file.
+        # For more info read here:
+        # https://applicaster.atlassian.net/wiki/spaces/~794659641/pages/1042022816/Building+Blocks
+        """
         try:
             self.building_blocks.boot_step()
         except Exception as exp:
@@ -72,6 +80,11 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(0, 1, exp)
 
     def __setup_building_blocks__(self):
+        """
+        # For more info about this method read here:
+        # https://applicaster.atlassian.net/wiki/spaces/~794659641/pages/1042022816/Building+Blocks
+        # :return: None
+        """
         try:
             building_blocks_path = Configuration.get_instance().get('general', 'building_blocks')
             spec = spec_from_file_location('BuildingBlocks', '%s/%s' % (ROOT_DIR, building_blocks_path))
@@ -89,5 +102,11 @@ class BaseTest(unittest.TestCase):
         self.driver.terminate_app()
 
     def __setup_analytics_manager__(self):
+        """
+        # Analytics manager object is being setup only if the tester added in the config.cfg file pointer to some log
+        # file. Analytics manager idea is to search for events inside log file. The manager assumes that a line with
+        # prefix of AutomationAnalyticsEvent contain inside analytic event.
+        # :return: None
+        """
         if Configuration.get_instance().get('general', 'yarn_server_log'):
             self.analytics_manager = AnalyticsManager()


### PR DESCRIPTION
This PR adds manger for verifying analytics events. 

The manager is not testing the events reporting against the actually provider, i.e google, the idea behind is that the QB project prints the events to some log file once an event was fired to a real analytics provider, and the test is verifying that the events is found in the log file. 