### PR TITLE
feat(hook-tests): remove if condition for dismissing hook screen in android mobile tests

### DIFF
--- a/applications/feature_app/config.cfg
+++ b/applications/feature_app/config.cfg
@@ -15,7 +15,7 @@ automationName = XCUITest
 # ============================== Android Mobile Emulator ============================== #
 [general]
 platform = Android
-app_version = 0.2.0.2
+app_version = 0.2.0.3
 app_id = 5a364b49e03b2f000d51a0de
 building_blocks = applications/feature_app/mobile/building_blocks/building_blocks.py
 

--- a/applications/feature_app/mobile/tests/test_google_ima.py
+++ b/applications/feature_app/mobile/tests/test_google_ima.py
@@ -111,10 +111,10 @@ class GoogleInteractiveMediaAdsTests(BaseTest):
         PRINT('Step 2: Press on item "%s" element on screen' % VMAP_VOD_ITEM_NAME)
         element = self.driver.find_element_by_text(VMAP_VOD_ITEM_NAME)
         element.click()
-        if Configuration.get_instance().platform_type() == PlatformType.IOS:
-            PRINT('     Step 2.1: Wait for pre hook and dismiss it')
-            self.driver.wait(2)
-            pre_hook.enter_with_success()
+
+        PRINT('     Step 2.1: Wait for pre hook and dismiss it')
+        self.driver.wait(2)
+        pre_hook.enter_with_success()
 
         self.verify_adv(3, 'pre-roll', 20, 15, VMAP_PRE_ROLL_URL)
         self.verify_adv(4, 'mid-roll', 30, 15, VMAP_MID_ROLL_URL)

--- a/applications/feature_app/mobile/tests/test_grid_component.py
+++ b/applications/feature_app/mobile/tests/test_grid_component.py
@@ -32,13 +32,11 @@ class GridComponentTests(BaseTest):
     def test_play_vod_item_in_feed_of_feeds_connected_screen(self):
         grid_screen = self.building_blocks.screens['GridScreen']
         pre_hook = self.building_blocks.screens['demo_pre_hook']
-        platform_type = Configuration.get_instance().platform_type()
 
         PRINT('Step 1: Navigate to "GridScreen" screen')
         grid_screen.navigate()
 
-        item_name = 'item_0' if platform_type == PlatformType.ANDROID else '000'
-
+        item_name = 'item_0' if PLATFORM == PlatformType.ANDROID else '000'
         self.search_and_press(
             item_name,
             grid_screen,
@@ -47,7 +45,7 @@ class GridComponentTests(BaseTest):
             3
         )
 
-        item_name = 'child_item_0' if platform_type == PlatformType.ANDROID else 'child_000'
+        item_name = 'child_item_0' if PLATFORM == PlatformType.ANDROID else 'child_000'
         self.search_and_press(
             item_name,
             grid_screen,
@@ -56,13 +54,12 @@ class GridComponentTests(BaseTest):
             1
         )
 
-        if Configuration.get_instance().platform_type() == PlatformType.IOS:
-            PRINT('Step 4: Verify that the pre hook screen is presented and dismiss it')
-            pre_hook.verify_in_screen(retries=3)
-            PRINT('     Step 4.1: Pre hook screen is presented correctly')
-            pre_hook.enter_with_success()
-            PRINT('     Step 4.2: Pre hook screen dismissed')
-            PRINT('     Step 4.3: Wait 10 seconds until the streaming will start')
+        PRINT('Step 4: Verify that the pre hook screen is presented and dismiss it')
+        pre_hook.verify_in_screen(retries=5)
+        PRINT('     Step 4.1: Pre hook screen is presented correctly')
+        pre_hook.enter_with_success()
+        PRINT('     Step 4.2: Pre hook screen dismissed')
+        PRINT('     Step 4.3: Wait 10 seconds until the streaming will start')
 
         PRINT('Wait 10 seconds until that the streaming will start')
         self.driver.wait(10)

--- a/applications/feature_app/mobile/tests/test_player.py
+++ b/applications/feature_app/mobile/tests/test_player.py
@@ -33,9 +33,9 @@ class PlayerTests(BaseTest):
             PRINT('     Step 2.5: Dismiss the pre hook screen with success')
             pre_hook.enter_with_success()
 
-        PRINT('     Step 2.3: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
+        PRINT('     Step 2.6: Wait %s seconds until the streaming will start' % START_PLAYING_VOD_TIMEOUT)
         self.driver.wait(START_PLAYING_VOD_TIMEOUT)
-        PRINT('     Step 2.4: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
+        PRINT('     Step 2.7: Finished waiting the %s seconds' % START_PLAYING_VOD_TIMEOUT)
 
     @pytest.mark.qb_ios_mobile
     @pytest.mark.qb_android_mobile_nightly


### PR DESCRIPTION
We had so far today a condition in the android mobile pre-hook tests, to verify existence of hook plugin before paying an item in the player, since we did not have hook plugin for Android platform. 

Plugin was added lately and the condition is not needed anymore. 
