### PR TITLE
fix: fix samsung screen picker tests

### DIFF
--- a/applications/feature_app/tv/tests/test_focus_manager.py
+++ b/applications/feature_app/tv/tests/test_focus_manager.py
@@ -198,11 +198,11 @@ class FocusManagerTests(BaseTest):
             accessibility_id
         )
 
-        accessibility_id = 'focusable-PickerSelector.ScreenPickerContainer.b859d004-d3a2-42e5-8312-260d51d2fa12-PickerItem.94222.1'
+        accessibility_id = 'focusable-PickerSelector.ScreenPickerContainer.b859d004-d3a2-42e5-8312-260d51d2fa12-PickerItem.94224.1'
         move_focus_and_verify(
             self.driver,
             6,
-            'move focus manger to the second tab in the screen picker (screen_2) and verify that screen_2 is focused',
+            'move focus manger to the second tab in the screen picker (screen_4) and verify that screen_2 is focused',
             [RemoteControlKeys.LEFT, RemoteControlKeys.LEFT, RemoteControlKeys.LEFT,
                 RemoteControlKeys.DOWN, RemoteControlKeys.ENTER],
             accessibility_id

--- a/applications/feature_app/tv/tests/test_zapp_sanity.py
+++ b/applications/feature_app/tv/tests/test_zapp_sanity.py
@@ -241,6 +241,7 @@ class HeroScreenTest(BaseTest):
 @pytest.mark.android_tv_nightly
 @pytest.mark.tv_os_nightly
 @pytest.mark.samsung_tv
+@pytest.mark.do_test
 @pytest.mark.usefixtures('automation_driver')
 class ScreenPickerScreenTest(BaseTest):
     def test_screen_picker(self):
@@ -253,7 +254,7 @@ class ScreenPickerScreenTest(BaseTest):
             self.driver,
             2,
             'Step 2: verify that the screen picker tabs texts are showing on screen',
-            ['screen_1', 'screen_2', 'screen_3', 'screen_4',
+            ['screen_1', 'screen_4',
                 'applicaster_cell_types', 'video_feed', 'current_program_feed']
         )
 


### PR DESCRIPTION
This PR fixes UI tests for samsung which were still using old components that are removed